### PR TITLE
🐛 fix(index.css): 다크모드 미지원에 따른 media query 제거

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -88,7 +88,7 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: transparent;
   cursor: pointer;
   transition: border-color 0.25s;
 }
@@ -96,19 +96,4 @@ button {
 button:not([class*="inline-flex"]):focus,
 button:not([class*="inline-flex"]):focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-
-  a:hover {
-    color: #747bff;
-  }
-
-  button {
-    background-color: #f9f9f9;
-  }
 }


### PR DESCRIPTION
<img width="300" height="200" alt="image" src="https://github.com/user-attachments/assets/e3e11381-ea7a-496d-987d-74dd6e74dacd" />
<img width="300" height="200" alt="image" src="https://github.com/user-attachments/assets/35704e60-2af2-4dcb-bb93-31115d82ee6c" />

## 기존 상황
* 다크모드 지원여부에 따른 논의사항이 없는 상태
  * 추후 필요하다면 회의 후 추가
* global css(`index.css`)에서 button의 background-color가 브라우저 모드 (다크모드, 라이트모드)에 따라서 다르게 지정되고 있었음
* 이에 따라 기존 calendar 스타일의 통일성을 해치게 되었음

## 개선 사항
<img width="295" height="261" alt="Screenshot 2026-01-08 at 00 52 03" src="https://github.com/user-attachments/assets/ed0afb98-bca3-4b8e-af96-010eb1293d52" />

* 라이트모드, 다크모드에서 일관된 캘린더 스타일을 보여주게 수정
* media query 제거 및 기본 `background-color: transparent` 로 지정