### PR TITLE
feat: 로그인 후 accessToken, refreshToken 저장 로직 추가

### DIFF
--- a/frontend/src/entities/session/lib/init.ts
+++ b/frontend/src/entities/session/lib/init.ts
@@ -1,11 +1,13 @@
 import { authApi, UNAUTHORIZED_EVENT } from '@/shared/api'
 import { useSessionStore } from '../model/store'
+import { useTokenStore } from '@/shared/lib'
 
 // 401 에러가 발생했을 때 이를 감지하고 처리
 export const initSessionListener = () => {
     if (typeof window !== 'undefined') {
         window.addEventListener(UNAUTHORIZED_EVENT, () => {
             authApi.logout().finally(() => {
+                useTokenStore.getState().removeAccessToken()
                 useSessionStore.getState().clearSession()
             })
         })

--- a/frontend/src/entities/session/model/store.ts
+++ b/frontend/src/entities/session/model/store.ts
@@ -10,9 +10,11 @@ import { tokenService } from '@/shared/lib'
 interface SessionState {
     user: Member | null
     organization: Organization | null
+    accessToken: string | null
     isLoading: boolean
     isInitialized: boolean
     setSession: (user: Member, organization: Organization) => void
+    setAccessToken: (token: string) => void
     clearSession: () => void
     fetchSession: () => Promise<void>
     // TODO: organization switch 시에 영향을 받는 reservation, room과 같은 store를 같은 생명주기로 관리
@@ -22,12 +24,17 @@ interface SessionState {
 export const useSessionStore = create<SessionState>((set) => ({
     user: null,
     organization: null,
+    accessToken: null,
     isLoading: false,
     isInitialized: false,
     setSession: (user, organization) => set({ user, organization }),
+    setAccessToken: (token) => {
+        tokenService.setAccessToken(token)
+        set({ accessToken: token })
+    },
     clearSession: () => {
         tokenService.removeAccessToken()
-        set({ user: null, organization: null })
+        set({ user: null, organization: null, accessToken: null })
     },
     switchOrganization: (organization) => {
         set({ organization })

--- a/frontend/src/entities/session/model/store.ts
+++ b/frontend/src/entities/session/model/store.ts
@@ -4,6 +4,7 @@ import { Member, Organization } from '@/entities/user'
 import { useRoomStore } from '@/entities/room'
 import { useReservationStore } from '@/entities/reservation'
 import { authApi } from '@/shared/api'
+import { tokenService } from '@/shared/lib'
 
 
 interface SessionState {
@@ -24,7 +25,10 @@ export const useSessionStore = create<SessionState>((set) => ({
     isLoading: false,
     isInitialized: false,
     setSession: (user, organization) => set({ user, organization }),
-    clearSession: () => set({ user: null, organization: null }),
+    clearSession: () => {
+        tokenService.removeAccessToken()
+        set({ user: null, organization: null })
+    },
     switchOrganization: (organization) => {
         set({ organization })
 

--- a/frontend/src/entities/session/model/store.ts
+++ b/frontend/src/entities/session/model/store.ts
@@ -4,17 +4,13 @@ import { Member, Organization } from '@/entities/user'
 import { useRoomStore } from '@/entities/room'
 import { useReservationStore } from '@/entities/reservation'
 import { authApi } from '@/shared/api'
-import { tokenService } from '@/shared/lib'
-
 
 interface SessionState {
     user: Member | null
     organization: Organization | null
-    accessToken: string | null
     isLoading: boolean
     isInitialized: boolean
     setSession: (user: Member, organization: Organization) => void
-    setAccessToken: (token: string) => void
     clearSession: () => void
     fetchSession: () => Promise<void>
     // TODO: organization switch 시에 영향을 받는 reservation, room과 같은 store를 같은 생명주기로 관리
@@ -24,17 +20,12 @@ interface SessionState {
 export const useSessionStore = create<SessionState>((set) => ({
     user: null,
     organization: null,
-    accessToken: null,
     isLoading: false,
     isInitialized: false,
     setSession: (user, organization) => set({ user, organization }),
-    setAccessToken: (token) => {
-        tokenService.setAccessToken(token)
-        set({ accessToken: token })
-    },
+
     clearSession: () => {
-        tokenService.removeAccessToken()
-        set({ user: null, organization: null, accessToken: null })
+        set({ user: null, organization: null })
     },
     switchOrganization: (organization) => {
         set({ organization })

--- a/frontend/src/features/login/model/useLogin.ts
+++ b/frontend/src/features/login/model/useLogin.ts
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useSessionStore } from '@/entities/session'
 import { authApi } from '@/shared/api'
+import { tokenService } from '@/shared/lib'
 
 export const useLogin = () => {
     const [isLoading, setIsLoading] = useState(false)
@@ -18,8 +19,10 @@ export const useLogin = () => {
 
         setIsLoading(true)
         try {
-            const success = await authApi.login(username, password)
-            if (success) {
+            const accessToken = await authApi.login(username, password)
+            if (accessToken) {
+                tokenService.setAccessToken(accessToken)
+                // 로그인에 성공하면 전달받은 accessToken을 이용하여 사용자와 조직 정보를 요청
                 await useSessionStore.getState().fetchSession()
                 navigate(from, { replace: true })
             } else {

--- a/frontend/src/features/login/model/useLogin.ts
+++ b/frontend/src/features/login/model/useLogin.ts
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useSessionStore } from '@/entities/session'
 import { authApi } from '@/shared/api'
-import { tokenService } from '@/shared/lib'
+
 
 export const useLogin = () => {
     const [isLoading, setIsLoading] = useState(false)
@@ -21,7 +21,7 @@ export const useLogin = () => {
         try {
             const accessToken = await authApi.login(username, password)
             if (accessToken) {
-                tokenService.setAccessToken(accessToken)
+                useSessionStore.getState().setAccessToken(accessToken)
                 // 로그인에 성공하면 전달받은 accessToken을 이용하여 사용자와 조직 정보를 요청
                 await useSessionStore.getState().fetchSession()
                 navigate(from, { replace: true })

--- a/frontend/src/features/login/model/useLogin.ts
+++ b/frontend/src/features/login/model/useLogin.ts
@@ -1,36 +1,38 @@
 import { useState } from 'react'
-import { useNavigate, useLocation } from 'react-router-dom'
 import { useSessionStore } from '@/entities/session'
 import { authApi } from '@/shared/api'
-
+import { useTokenStore } from '@/shared/lib'
 
 export const useLogin = () => {
     const [isLoading, setIsLoading] = useState(false)
-    const navigate = useNavigate()
-    const location = useLocation()
-    const from = location.state?.from?.pathname || '/'
 
     // TODO: 아이디와 비밀번호 유효성 검사 - 공통 컴포넌트로 수정 예정
-    const login = async (username?: string, password?: string) => {
+    const login = async (username?: string, password?: string): Promise<{ success: boolean; errorMessage?: string }> => {
         if (!username || !password) {
-            alert('아이디와 비밀번호를 입력해주세요.')
-            return
+            return { success: false, errorMessage: '아이디와 비밀번호를 입력해주세요.' }
         }
 
         setIsLoading(true)
+
         try {
             const accessToken = await authApi.login(username, password)
             if (accessToken) {
-                useSessionStore.getState().setAccessToken(accessToken)
+                useTokenStore.getState().setAccessToken(accessToken)
                 // 로그인에 성공하면 전달받은 accessToken을 이용하여 사용자와 조직 정보를 요청
                 await useSessionStore.getState().fetchSession()
-                navigate(from, { replace: true })
+
+                if (useSessionStore.getState().user) {
+                    return { success: true }
+                } else {
+                    useTokenStore.getState().removeAccessToken()
+                    return { success: false, errorMessage: '사용자 정보를 불러오는데 실패했습니다. 다시 시도해주세요.' }
+                }
             } else {
-                alert('로그인에 실패했습니다. 아이디와 비밀번호를 확인해주세요.')
+                return { success: false, errorMessage: '로그인에 실패했습니다. 아이디와 비밀번호를 확인해주세요.' }
             }
         } catch (error) { // TODO: 5xx 에러 처리는 중앙화하여 처리 예정
             console.error('Login failed', error)
-            alert('로그인 중 오류가 발생했습니다.')
+            return { success: false, errorMessage: '로그인 중 오류가 발생했습니다.' }
         } finally {
             setIsLoading(false)
         }

--- a/frontend/src/features/login/ui/LoginButton.tsx
+++ b/frontend/src/features/login/ui/LoginButton.tsx
@@ -1,5 +1,6 @@
 import { useLogin } from '../model'
 import { Button } from '@/shared/ui'
+import { useNavigate, useLocation } from 'react-router-dom'
 
 interface LoginButtonProps {
     username?: string
@@ -8,9 +9,17 @@ interface LoginButtonProps {
 
 export const LoginButton = ({ username, password }: LoginButtonProps) => {
     const { login, isLoading } = useLogin()
+    const navigate = useNavigate()
+    const location = useLocation()
+    const from = location.state?.from?.pathname || '/'
 
-    const handleLogin = () => {
-        login(username, password)
+    const handleLogin = async () => {
+        const { success, errorMessage } = await login(username, password)
+        if (success) {
+            navigate(from, { replace: true })
+        } else if (errorMessage) {
+            alert(errorMessage)
+        }
     }
 
     return (

--- a/frontend/src/shared/api/HttpClient.ts
+++ b/frontend/src/shared/api/HttpClient.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios'
+import { tokenService } from '@/shared/lib'
 
 export const UNAUTHORIZED_EVENT = 'unauthorized'
 
@@ -17,6 +18,17 @@ instance.interceptors.response.use(
         }
         return Promise.reject(error)
     },
+)
+
+instance.interceptors.request.use(
+    (config) => {
+        const accessToken = tokenService.getAccessToken()
+        if (accessToken) {
+            config.headers.Authorization = `Bearer ${accessToken}`
+        }
+        return config
+    },
+    (error) => Promise.reject(error),
 )
 
 export const httpClient = {

--- a/frontend/src/shared/api/HttpClient.ts
+++ b/frontend/src/shared/api/HttpClient.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios'
-import { tokenService } from '@/shared/lib'
+import { useTokenStore } from '@/shared/lib'
 
 export const UNAUTHORIZED_EVENT = 'unauthorized'
 
@@ -22,7 +22,7 @@ instance.interceptors.response.use(
 
 instance.interceptors.request.use(
     (config) => {
-        const accessToken = tokenService.getAccessToken()
+        const accessToken = useTokenStore.getState().accessToken
         if (accessToken) {
             config.headers.Authorization = `Bearer ${accessToken}`
         }

--- a/frontend/src/shared/api/auth.ts
+++ b/frontend/src/shared/api/auth.ts
@@ -23,13 +23,18 @@ export const authApi = {
             return null
         }
     },
-    // TODO: 로그인 후 세션 및 유저 정보 저장
-    login: async (username?: string, password?: string): Promise<boolean> => {
+    login: async (username?: string, password?: string): Promise<string | null> => {
         try {
-            const response = await httpClient.post('/api/login', { username, password })
-            return response.status === 200
+            const response = await httpClient.post<{
+                accessToken: string
+            }>('/api/login', { username, password })
+
+            if (response.status === 200 && response.data.accessToken) {
+                return response.data.accessToken
+            }
+            return null
         } catch {
-            return false
+            return null
         }
     },
     logout: async (): Promise<boolean> => {

--- a/frontend/src/shared/api/auth.ts
+++ b/frontend/src/shared/api/auth.ts
@@ -16,7 +16,7 @@ export interface AuthSessionResponse {
 export const authApi = {
     getUserSession: async (): Promise<AuthSessionResponse | null> => {
         try {
-            const response = await httpClient.get<AuthSessionResponse>('/api/me')
+            const response = await httpClient.get<AuthSessionResponse>('/v1/users/me')
             return response.data
         } catch (error) {
             console.error('Auth API Error:', error)
@@ -27,7 +27,7 @@ export const authApi = {
         try {
             const response = await httpClient.post<{
                 accessToken: string
-            }>('/api/login', { username, password })
+            }>('/v1/users/login', { username, password })
 
             if (response.status === 200 && response.data.accessToken) {
                 return response.data.accessToken
@@ -39,7 +39,7 @@ export const authApi = {
     },
     logout: async (): Promise<boolean> => {
         try {
-            const response = await httpClient.post('/api/logout')
+            const response = await httpClient.post('/v1/users/logout')
             return response.status === 200
         } catch {
             return false

--- a/frontend/src/shared/api/mocks/handlers.ts
+++ b/frontend/src/shared/api/mocks/handlers.ts
@@ -18,8 +18,8 @@ const createMockJwt = (userId: string) => {
 
 // service worker가 http 요청을 가로채서 처리 
 export const handlers = [
-    // 1. GET /api/me
-    http.get('/api/me', ({ request }) => {
+    // 1. GET /v1/users/me
+    http.get('/v1/users/me', ({ request }) => {
         const authHeader = request.headers.get('Authorization')
         if (!authHeader || !authHeader.startsWith('Bearer ')) {
             return new HttpResponse(null, { status: 401 })
@@ -35,8 +35,8 @@ export const handlers = [
         })
     }),
 
-    // 0. POST /api/login
-    http.post('/api/login', async ({ request }) => {
+    // 0. POST /v1/users/login
+    http.post('/v1/users/login', async ({ request }) => {
         try {
             const body = (await request.json()) as { username?: string; password?: string }
             const { username, password } = body
@@ -71,8 +71,8 @@ export const handlers = [
         }
     }),
 
-    // 0. POST /api/logout
-    http.post('/api/logout', () => {
+    // 0. POST /v1/users/logout
+    http.post('/v1/users/logout', () => {
         return HttpResponse.json(
             { success: true },
             {

--- a/frontend/src/shared/api/mocks/handlers.ts
+++ b/frontend/src/shared/api/mocks/handlers.ts
@@ -3,13 +3,25 @@ import { MOCK_ROOMS, RECENT_MEETINGS, MOCK_SCHEDULE_RESPONSE, MOCK_USER } from '
 
 const VALID_PASSWORD = 'password123!'
 
+const createMockJwt = (userId: string) => {
+    const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+    const payload = btoa(
+        JSON.stringify({
+            sub: userId,
+            exp: Math.floor(Date.now() / 1000) + 60 * 60, // 1 hour
+            iat: Math.floor(Date.now() / 1000),
+        }),
+    )
+    const signature = btoa('mock-signature')
+    return `${header}.${payload}.${signature}`
+}
+
 // service worker가 http 요청을 가로채서 처리 
 export const handlers = [
     // 1. GET /api/me
-    http.get('/api/me', () => {
-        const isAuthenticated = sessionStorage.getItem('is-authenticated')
-
-        if (!isAuthenticated) {
+    http.get('/api/me', ({ request }) => {
+        const authHeader = request.headers.get('Authorization')
+        if (!authHeader || !authHeader.startsWith('Bearer ')) {
             return new HttpResponse(null, { status: 401 })
         }
 
@@ -35,9 +47,21 @@ export const handlers = [
                 return new HttpResponse(null, { status: 500 })
             }
 
+            // 가상의 accessToken과 refreshToken 생성
             if (username === MOCK_USER.username && password === VALID_PASSWORD) {
-                sessionStorage.setItem('is-authenticated', 'true')
-                return HttpResponse.json({ success: true })
+                const accessToken = createMockJwt(MOCK_USER.memberId)
+                const refreshToken = createMockJwt(MOCK_USER.memberId)
+
+                return HttpResponse.json(
+                    {
+                        accessToken,
+                    },
+                    {
+                        headers: {
+                            'Set-Cookie': `refreshToken=${refreshToken}; Path=/; HttpOnly; Secure; SameSite=Strict`,
+                        },
+                    },
+                )
             }
 
             return new HttpResponse(null, { status: 401 })
@@ -47,10 +71,16 @@ export const handlers = [
         }
     }),
 
-    // 0. POSt /api/logout
+    // 0. POST /api/logout
     http.post('/api/logout', () => {
-        sessionStorage.removeItem('is-authenticated')
-        return HttpResponse.json({ success: true })
+        return HttpResponse.json(
+            { success: true },
+            {
+                headers: {
+                    'Set-Cookie': 'refreshToken=; Path=/; Max-Age=0',
+                },
+            },
+        )
     }),
 
     // 2. GET /api/rooms

--- a/frontend/src/shared/lib/index.ts
+++ b/frontend/src/shared/lib/index.ts
@@ -1,2 +1,3 @@
 export * from './utils'
 export * from './date'
+export * from './token'

--- a/frontend/src/shared/lib/token.ts
+++ b/frontend/src/shared/lib/token.ts
@@ -1,14 +1,13 @@
-// 메모리 상에 토큰을 저장 (새로고침 시 초기화됨에 주의)
-let _accessToken: string | null = null
+import { create } from 'zustand'
 
-export const tokenService = {
-    getAccessToken: (): string | null => {
-        return _accessToken
-    },
-    setAccessToken: (token: string): void => {
-        _accessToken = token
-    },
-    removeAccessToken: (): void => {
-        _accessToken = null
-    },
+interface TokenState {
+    accessToken: string | null
+    setAccessToken: (token: string) => void
+    removeAccessToken: () => void
 }
+
+export const useTokenStore = create<TokenState>((set) => ({
+    accessToken: null,
+    setAccessToken: (token) => set({ accessToken: token }),
+    removeAccessToken: () => set({ accessToken: null }),
+}))

--- a/frontend/src/shared/lib/token.ts
+++ b/frontend/src/shared/lib/token.ts
@@ -1,0 +1,13 @@
+export const ACCESS_TOKEN_KEY = 'accessToken'
+
+export const tokenService = {
+    getAccessToken: (): string | null => {
+        return sessionStorage.getItem(ACCESS_TOKEN_KEY)
+    },
+    setAccessToken: (token: string): void => {
+        sessionStorage.setItem(ACCESS_TOKEN_KEY, token)
+    },
+    removeAccessToken: (): void => {
+        sessionStorage.removeItem(ACCESS_TOKEN_KEY)
+    },
+}

--- a/frontend/src/shared/lib/token.ts
+++ b/frontend/src/shared/lib/token.ts
@@ -1,13 +1,14 @@
-export const ACCESS_TOKEN_KEY = 'accessToken'
+// 메모리 상에 토큰을 저장 (새로고침 시 초기화됨에 주의)
+let _accessToken: string | null = null
 
 export const tokenService = {
     getAccessToken: (): string | null => {
-        return sessionStorage.getItem(ACCESS_TOKEN_KEY)
+        return _accessToken
     },
     setAccessToken: (token: string): void => {
-        sessionStorage.setItem(ACCESS_TOKEN_KEY, token)
+        _accessToken = token
     },
     removeAccessToken: (): void => {
-        sessionStorage.removeItem(ACCESS_TOKEN_KEY)
+        _accessToken = null
     },
 }


### PR DESCRIPTION
로그인 API 요청 후 accessToken과 refreshToken 저장 로직 추가하였습니다.

**1. accessToken → sessionStorage 저장**
탭이나 브라우저가 닫히면 세션이 지워지기 때문에 토큰 탈취에 대한 위험을 줄일 수 있다고 판단하였습니다.

**2. refreshToken → cookie 저장**
MSW는 실제 백엔드 서버가 아니므로, Set-Cookie로 받은 쿠키를 브라우저가 자동으로 관리해주지 않을 때를 대비해 localStorage에 __msw-cookie-store__라는 이름으로 쿠키 정보를 저장하고 있습니다. 현재는 localStroage에 refreshToken이 저장되어 있는 걸로 확인되지만, 추후 백엔드와 연동하게 되면 이 부분은 크게 문제 없을 것이라 예상됩니다.

**3. 로그인 api 요청 성공 후 /v1/users/me 요청하여 사용자 정보 요청**
현재 메인화면에서 사용자 정보와 조직 정보를 출력하고 있습니다. 따라서 로그인 성공 후 사용자 정보를 요청하여 setSession을 통해 저장하고 있습니다.
 